### PR TITLE
7-bit encoding removed

### DIFF
--- a/Домашнее чтение/09_02_2015/keynote.tex
+++ b/Домашнее чтение/09_02_2015/keynote.tex
@@ -1,7 +1,6 @@
 \documentclass[10pt,a4paper]{article}
 \usepackage[utf8]{inputenc}
 \usepackage[russian]{babel}
-\usepackage[OT1]{fontenc}
 \usepackage{amsmath}
 \usepackage{amsfonts}
 \usepackage{amssymb}

--- a/Домашнее чтение/16_02_2015/next_essay.tex
+++ b/Домашнее чтение/16_02_2015/next_essay.tex
@@ -1,7 +1,6 @@
 \documentclass[10pt,a4paper]{article}
 \usepackage[utf8]{inputenc}
 \usepackage[russian]{babel}
-\usepackage[OT1]{fontenc}
 \usepackage{amsmath}
 \usepackage{amsfonts}
 \usepackage{amssymb}

--- a/Отчеты/01_LaTeX_Git_GPG/report.tex
+++ b/Отчеты/01_LaTeX_Git_GPG/report.tex
@@ -1,7 +1,6 @@
 \documentclass[10pt,a4paper]{article}
 \usepackage[utf8]{inputenc}
 \usepackage[russian]{babel}
-\usepackage[OT1]{fontenc}
 \usepackage{amsmath}
 \usepackage{amsfonts}
 \usepackage{amssymb}

--- a/Отчеты/02_Metasploit/report.tex
+++ b/Отчеты/02_Metasploit/report.tex
@@ -1,7 +1,6 @@
 \documentclass[10pt,a4paper]{article}
 \usepackage[utf8]{inputenc}
 \usepackage[russian]{babel}
-\usepackage[OT1]{fontenc}
 \usepackage{amsmath}
 \usepackage{amsfonts}
 \usepackage{amssymb}

--- a/Отчеты/03_AirCrack/report.tex
+++ b/Отчеты/03_AirCrack/report.tex
@@ -1,7 +1,6 @@
 \documentclass[10pt,a4paper]{article}
 \usepackage[utf8]{inputenc}
 \usepackage[russian]{babel}
-\usepackage[OT1]{fontenc}
 \usepackage{amsmath}
 \usepackage{amsfonts}
 \usepackage{amssymb}

--- a/Отчеты/04_WebGoat/report.tex
+++ b/Отчеты/04_WebGoat/report.tex
@@ -1,7 +1,6 @@
 \documentclass[10pt,a4paper]{article}
 \usepackage[utf8]{inputenc}
 \usepackage[russian]{babel}
-\usepackage[OT1]{fontenc}
 \usepackage{amsmath}
 \usepackage{amsfonts}
 \usepackage{amssymb}

--- a/Отчеты/Additional/report.tex
+++ b/Отчеты/Additional/report.tex
@@ -1,7 +1,6 @@
 \documentclass[10pt,a4paper]{article}
 \usepackage[utf8]{inputenc}
 \usepackage[russian]{babel}
-\usepackage[OT1]{fontenc}
 \usepackage{amsmath}
 \usepackage{amsfonts}
 \usepackage{amssymb}

--- a/Отчеты/Programming/report.tex
+++ b/Отчеты/Programming/report.tex
@@ -1,7 +1,6 @@
 \documentclass[12pt,a4paper]{report}
 \usepackage[utf8]{inputenc}
 \usepackage[russian]{babel}
-\usepackage[OT1]{fontenc}
 \usepackage{amsmath}
 \usepackage{amsfonts}
 \usepackage{amssymb}


### PR DESCRIPTION
Нет необходимости в подключении 7-битной кодировки, OT1 будет подключен автоматически.
Но использоваться будет T2A (*\usepackage[russian]{babel}*).